### PR TITLE
Organization events

### DIFF
--- a/components/events/CreateEventModal.tsx
+++ b/components/events/CreateEventModal.tsx
@@ -14,10 +14,12 @@ export default function CreateEventModal({ onClose, onSubmit, error }: CreateEve
   const [organizations, setOrganizations] = useState<Organization[]>([]);
 
   useEffect(() => {
-    api.getOrganizations().then((data) => {
-      const orgs = Array.isArray(data) ? data : JSON.parse(data as unknown as string);
-      setOrganizations(orgs);
-    });
+    Promise.all([api.getOrganizations(), api.getUserOrganizationBindingsForCurrentUser()])
+      .then(([orgsData, bindings]) => {
+        const allOrgs: Organization[] = Array.isArray(orgsData) ? orgsData : JSON.parse(orgsData as unknown as string);
+        const boundOrgIds = new Set(bindings.map((b) => b.organizationId));
+        setOrganizations(allOrgs.filter((org) => boundOrgIds.has(org.id)));
+      });
   }, []);
 
   return (

--- a/components/events/EventsPage.tsx
+++ b/components/events/EventsPage.tsx
@@ -36,12 +36,10 @@ export default function EventsPage() {
   async function handleCreate(data: { title: string; description: string; attachment: Attachment | null; organizationId: number; startDate: string; ageLimit: number }) {
     setCreateError(null);
     try {
-      const binding = await api.getUserOrganizationBindingForCurrentUser(data.organizationId);
-      const bindingId = binding?.id ?? 0;
       await api.createOrganizationEvent({
         id: 0,
         organizationId: data.organizationId,
-        userOrganizationBindingId: bindingId,
+        userOrganizationBindingId: 0,
         title: data.title,
         description: data.description,
         attachment: data.attachment,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -76,7 +76,7 @@ export type OrganizationEvent = {
   ageLimit?: number;
   creatorName?: string;
 };
-export type UserOrganizationBinding = { id: number };
+export type UserOrganizationBinding = { id: number; organizationId: number };
 export type GdprDeleteResult = boolean;
 
 type RawOrganization = {
@@ -237,6 +237,8 @@ export const api = {
     request<UserOrganizationBinding[]>(
       `/UserOrganizationBinding/${organizationId}`
     ),
+  getUserOrganizationBindingsForCurrentUser: () =>
+    request<UserOrganizationBinding[]>(`/UserOrganizationBinding/me`),
   getUserOrganizationBindingForCurrentUser: (organizationId: number) =>
     request<UserOrganizationBinding>(
       `/UserOrganizationBinding/${organizationId}/me`


### PR DESCRIPTION
Move UserOrganizationBindings check from the front-end to the back-end.
Limit organization options to the ones that the user is in when creating an event.